### PR TITLE
ci: modernize Go workflow and bump module to Go 1.23

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,18 +1,25 @@
 name: Go CI
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4.0.0
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version-file: go.mod
+          check-latest: true
 
       - name: Verify dependencies
         run: go mod verify
@@ -23,16 +30,20 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
-      - uses: dominikh/staticcheck-action@v1.3.0
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not gofmt'd:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Run staticcheck
+        uses: dominikh/staticcheck-action@v1
         with:
-          # renovate: datasource=go depName=honnef.co/go/tools/cmd/staticcheck
-          version: "2022.1.1"
-
-      - name: Install golint
-        run: go install golang.org/x/lint/golint@latest
-
-      - name: Run golint
-        run: golint ./...
+          version: latest
+          install-go: false
 
       - name: Run tests
-        run: go test -vet=off ./...
+        run: go test -race -vet=off ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mikaello/go-iof-xml
 
-go 1.20
+go 1.23
 
 require golang.org/x/net v0.9.0
 

--- a/pkg/iof_v2/iof_v2.go
+++ b/pkg/iof_v2/iof_v2.go
@@ -249,7 +249,7 @@ type EventClass struct {
 
 // TransferedToClass ...
 type TransferedToClass struct {
-	ClassId        *ClassId         `xml:"ClassId"`
+	ClassId        *ClassId        `xml:"ClassId"`
 	ClassShortName *ClassShortName `xml:"ClassShortName"`
 }
 
@@ -261,7 +261,7 @@ type DividedIntoClass struct {
 // EntryClass ...
 type EntryClass struct {
 	SequenceAttr   string          `xml:"sequence,attr,omitempty"`
-	ClassId        *ClassId         `xml:"ClassId"`
+	ClassId        *ClassId        `xml:"ClassId"`
 	ClassShortName *ClassShortName `xml:"ClassShortName"`
 	EventClass     *EventClass     `xml:"EventClass"`
 }
@@ -1167,8 +1167,8 @@ type Transaction struct {
 	Club               *Club           `xml:"Club"`
 	OrganisationId     *OrganisationId `xml:"OrganisationId"`
 	Organisation       *Organisation   `xml:"Organisation"`
-	PersonId           []*PersonId        `xml:"PersonId"`
-	Person             []*Person        `xml:"Person"`
+	PersonId           []*PersonId     `xml:"PersonId"`
+	Person             []*Person       `xml:"Person"`
 	EntryId            []string        `xml:"EntryId"`
 	ServiceOrderNumber []string        `xml:"ServiceOrderNumber"`
 	ServiceId          []string        `xml:"ServiceId"`

--- a/pkg/iof_v3/iof_v3.go
+++ b/pkg/iof_v3/iof_v3.go
@@ -236,7 +236,7 @@ type EventURL struct {
 	Value    string `xml:",chardata"`
 }
 
-// Schedule defines the schedule of sub-events that comprise the entire orienteering event, 
+// Schedule defines the schedule of sub-events that comprise the entire orienteering event,
 // e.g. banquets, social events and awards ceremonies.
 type Schedule struct {
 	ModifyTimeAttr string       `xml:"modifyTime,attr,omitempty"`


### PR DESCRIPTION
## Summary

- Modernises the GitHub Actions workflow: latest `actions/checkout` and `actions/setup-go`, Go version sourced from `go.mod`, PRs as a trigger, and a small `permissions:` block.
- Drops the archived `golint` step and adds a `gofmt` check in its place.
- Bumps the module's minimum Go version from 1.20 (out of support) to 1.23.

The existing CI was broken on `main` — the pinned `staticcheck-action@v1.3.0` with version `2022.1.1` can no longer install Go 1.19 on current runners. This PR fixes that and gives subsequent changes a green baseline to build on.

## Test plan

- [x] `go build ./...` passes locally
- [x] `go test -race ./...` passes locally
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `staticcheck ./...` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)