### PR TITLE
refactor!: rewrite marshallers package with idiomatic Go API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/mikaello/go-iof-xml
 
-go 1.23
+go 1.25.0
+
+require golang.org/x/net v0.54.0
+
+require golang.org/x/text v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
+golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=

--- a/pkg/marshallers/marshallers.go
+++ b/pkg/marshallers/marshallers.go
@@ -1,167 +1,186 @@
+// Package marshallers encodes and decodes IOF Interface Standard v3 XML
+// documents to and from the Go structs defined in
+// github.com/mikaello/go-iof-xml/pkg/iof_v3.
+//
+// Decoding accepts XML with or without a UTF-8 BOM and supports non-UTF-8
+// encodings declared in the XML prolog. The document type is identified
+// by the root element; use [Decode] when the type is not known statically
+// or [DecodeAs] for a typed result.
+//
+// JSON support is provided for convenience and mirrors the XML structure;
+// it is not part of the IOF data standard.
 package marshallers
 
 import (
+	"bytes"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"reflect"
-	"regexp"
 
 	"github.com/mikaello/go-iof-xml/pkg/iof_v3"
+	"golang.org/x/net/html/charset"
 )
 
-func getMainElementName(xml string) string {
-	re := regexp.MustCompile("<([A-Z][a-zA-Z]+)")
-	match := re.FindStringSubmatch(xml)
-	if match != nil {
-		return match[1]
-	}
-	return ""
+// Document is the union of IOF v3 root document types. The constraint is
+// used by [DecodeAs] to provide a typed unmarshalling helper.
+type Document interface {
+	iof_v3.CompetitorList |
+		iof_v3.OrganisationList |
+		iof_v3.EventList |
+		iof_v3.ClassList |
+		iof_v3.EntryList |
+		iof_v3.CourseData |
+		iof_v3.StartList |
+		iof_v3.ResultList |
+		iof_v3.ServiceRequestList |
+		iof_v3.ControlCardList
 }
 
-const UTF8_BOM = "\uFEFF"
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
-func removeUTF8BOM(s string, mainElement string) string {
-	if len(s) > 0 && s[0:len(UTF8_BOM)] == UTF8_BOM {
-		fmt.Printf("WARNING: removing BOM from XML of type %s\n", mainElement)
-		s = s[len(UTF8_BOM):]
-	}
-	return s
+// trimBOM strips a leading UTF-8 byte-order mark from data if present.
+func trimBOM(data []byte) []byte {
+	return bytes.TrimPrefix(data, utf8BOM)
 }
 
-func cleanAndUnmarshal(dirtyXml string, xmlType interface{}) interface{} {
-	xmlTypeName := reflect.TypeOf(xmlType).Elem().Name()
-	xmlData := removeUTF8BOM(dirtyXml, xmlTypeName)
+// newDecoder returns an xml.Decoder with a permissive charset reader so
+// non-UTF-8 documents (as declared in the XML prolog) can be decoded.
+func newDecoder(r io.Reader) *xml.Decoder {
+	dec := xml.NewDecoder(r)
+	dec.CharsetReader = charset.NewReaderLabel
+	return dec
+}
 
-	fmt.Printf("Unmarshalling %s.\n", xmlTypeName)
+// rootElementName returns the local name of the first XML start element in
+// data. It is tolerant of leading whitespace, the XML declaration,
+// comments and processing instructions.
+func rootElementName(data []byte) (string, error) {
+	dec := newDecoder(bytes.NewReader(data))
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			return "", fmt.Errorf("no root element found")
+		}
+		if err != nil {
+			return "", fmt.Errorf("read root element: %w", err)
+		}
+		if se, ok := tok.(xml.StartElement); ok {
+			return se.Name.Local, nil
+		}
+	}
+}
 
-	err := xml.Unmarshal([]byte(xmlData), xmlType)
+// Decode decodes an IOF v3 XML document. The returned value is a pointer
+// to one of the iof_v3 root types (e.g. *iof_v3.ResultList) determined by
+// the document's root element. Use a type switch or assertion to access it.
+func Decode(data []byte) (any, error) {
+	data = trimBOM(data)
+
+	name, err := rootElementName(data)
 	if err != nil {
-		fmt.Printf("ERROR: Failed to unmarshal XML (%s): %s\n", xmlTypeName, err)
+		return nil, err
 	}
 
-	return xmlType
-}
-
-func MarshallIofXml(element interface{}) (string, error) {
-	xmlContent, err := xml.MarshalIndent(element, "", "  ")
+	v, err := newDocument(name)
 	if err != nil {
-		return "", err
-	} else {
-		return xml.Header + string(xmlContent), nil
+		return nil, err
 	}
+
+	if err := newDecoder(bytes.NewReader(data)).Decode(v); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", name, err)
+	}
+	return v, nil
 }
 
-func MarshallToIofUnofficialJson(element interface{}) (string, error) {
-	jsonContent, err := json.MarshalIndent(element, "", "  ")
+// DecodeReader is like [Decode] but reads from r. r is fully consumed.
+func DecodeReader(r io.Reader) (any, error) {
+	data, err := io.ReadAll(r)
 	if err != nil {
-		return "", err
-	} else {
-		return string(jsonContent), nil
+		return nil, fmt.Errorf("read XML: %w", err)
 	}
+	return Decode(data)
 }
 
-// GenericUnmarshalV3Xml can be called with any valid IOF v3 XML document. You will need
-// to cast it to the correct type yourself.
-func GenericUnmarshalV3Xml(dirtyXml string) (interface{}, error) {
-	mainElementName := getMainElementName(dirtyXml)
-	xmlData := removeUTF8BOM(dirtyXml, mainElementName)
+// DecodeAs decodes an IOF v3 XML document into the specific type T.
+// It returns an error if the document's root element does not match T.
+//
+//	list, err := marshallers.DecodeAs[iof_v3.ResultList](data)
+func DecodeAs[T Document](data []byte) (*T, error) {
+	data = trimBOM(data)
 
-	type temp struct {
-		value interface{}
+	var v T
+	expected := typeName(&v)
+
+	name, err := rootElementName(data)
+	if err != nil {
+		return nil, err
+	}
+	if name != expected {
+		return nil, fmt.Errorf("root element is %q, want %q", name, expected)
 	}
 
-	actual := temp{}
+	if err := newDecoder(bytes.NewReader(data)).Decode(&v); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", expected, err)
+	}
+	return &v, nil
+}
 
-	switch mainElementName {
+// typeName returns the short Go type name of *T (e.g. "ResultList"), which
+// matches the XML root element name for IOF v3 documents.
+func typeName(v any) string {
+	t := reflect.TypeOf(v)
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t.Name()
+}
+
+// EncodeXML serialises an IOF v3 document into XML with the standard
+// declaration line and two-space indentation.
+func EncodeXML(v any) ([]byte, error) {
+	body, err := xml.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode XML: %w", err)
+	}
+	var buf bytes.Buffer
+	buf.WriteString(xml.Header)
+	buf.Write(body)
+	return buf.Bytes(), nil
+}
+
+// EncodeJSON serialises an IOF v3 document into indented JSON. The JSON
+// shape mirrors the Go structs and is not part of the IOF data standard.
+func EncodeJSON(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}
+
+// newDocument returns a pointer to a freshly allocated value of the iof_v3
+// type matching the given root element name.
+func newDocument(rootElement string) (any, error) {
+	switch rootElement {
 	case "CompetitorList":
-		actual.value = new(iof_v3.CompetitorList)
+		return new(iof_v3.CompetitorList), nil
 	case "OrganisationList":
-		actual.value = new(iof_v3.OrganisationList)
+		return new(iof_v3.OrganisationList), nil
 	case "EventList":
-		actual.value = new(iof_v3.EventList)
+		return new(iof_v3.EventList), nil
 	case "ClassList":
-		actual.value = new(iof_v3.ClassList)
+		return new(iof_v3.ClassList), nil
 	case "EntryList":
-		actual.value = new(iof_v3.EntryList)
+		return new(iof_v3.EntryList), nil
 	case "CourseData":
-		actual.value = new(iof_v3.CourseData)
+		return new(iof_v3.CourseData), nil
 	case "StartList":
-		actual.value = new(iof_v3.StartList)
+		return new(iof_v3.StartList), nil
 	case "ResultList":
-		actual.value = new(iof_v3.ResultList)
+		return new(iof_v3.ResultList), nil
 	case "ServiceRequestList":
-		actual.value = new(iof_v3.ServiceRequestList)
+		return new(iof_v3.ServiceRequestList), nil
 	case "ControlCardList":
-		actual.value = new(iof_v3.ControlCardList)
+		return new(iof_v3.ControlCardList), nil
 	default:
-		return nil, fmt.Errorf("unknown IOF v3 XML element: %s", mainElementName)
+		return nil, fmt.Errorf("unknown IOF v3 root element: %q", rootElement)
 	}
-
-	err := xml.Unmarshal([]byte(xmlData), &actual.value)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal IOF v3 XML (%s): %s", mainElementName, err)
-	}
-
-	return actual.value, nil
-}
-
-func UnmarshalIofV3CompetitorList(xml string) iof_v3.CompetitorList {
-	result := iof_v3.CompetitorList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3OrganisationList(xml string) iof_v3.OrganisationList {
-	result := iof_v3.OrganisationList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3EventList(xml string) iof_v3.EventList {
-	result := iof_v3.EventList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3ClassList(xml string) iof_v3.ClassList {
-	result := iof_v3.ClassList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3EntryList(xml string) iof_v3.EntryList {
-	result := iof_v3.EntryList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3CourseData(xml string) iof_v3.CourseData {
-	result := iof_v3.CourseData{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3StartList(xml string) iof_v3.StartList {
-	result := iof_v3.StartList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3ResultList(xml string) iof_v3.ResultList {
-	result := iof_v3.ResultList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3ServiceRequestList(xml string) iof_v3.ServiceRequestList {
-	result := iof_v3.ServiceRequestList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
-}
-
-func UnmarshalIofV3ControlCardList(xml string) iof_v3.ControlCardList {
-	result := iof_v3.ControlCardList{}
-	cleanAndUnmarshal(xml, &result)
-	return result
 }

--- a/pkg/marshallers/marshallers_test.go
+++ b/pkg/marshallers/marshallers_test.go
@@ -1,97 +1,192 @@
 package marshallers
 
 import (
-	"fmt"
-	"io"
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mikaello/go-iof-xml/pkg/iof_v3"
 )
 
-func TestUnmarshalAllV3Types(t *testing.T) {
-	dirPath := "../../test/v3-examples"
-	entries, err := os.ReadDir(dirPath)
+const examplesDir = "../../test/v3-examples"
+
+func TestDecodeAllExamples(t *testing.T) {
+	entries, err := os.ReadDir(examplesDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	var n int
 	for _, e := range entries {
 		if !strings.HasSuffix(e.Name(), ".xml") {
 			continue
 		}
-		file := readFile(filepath.Join(dirPath, e.Name()))
-		fmt.Println("Unmarshalling: " + e.Name())
-		_, err = GenericUnmarshalV3Xml(string(file))
-		if err != nil {
-			t.Error(err)
-		}
+		n++
+		t.Run(e.Name(), func(t *testing.T) {
+			data := readFile(t, filepath.Join(examplesDir, e.Name()))
+			if _, err := Decode(data); err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+		})
+	}
+	if n == 0 {
+		t.Fatalf("no example files found in %s", examplesDir)
 	}
 }
 
-func TestUnmarshalV3ResultList(t *testing.T) {
-	file := readFile("../../test/v3-examples/ResultList3.xml")
-	resultList := UnmarshalIofV3ResultList(string(file))
+func TestDecodeResultListFields(t *testing.T) {
+	data := readFile(t, filepath.Join(examplesDir, "ResultList3.xml"))
 
-	if resultList.Event.Name != "Example event" {
-		t.Errorf("Expected result list event name to be 'Example Event', found %s", resultList.Event.Name)
-	}
-	if resultList.Event.StartTime.Date != "2011-07-30" {
-		t.Errorf("Expected result list event start date to be '2011-07-30', found %s", resultList.Event.StartTime.Date)
-	}
-	if resultList.Event.StartTime.Time == nil {
-		t.Fatal("Expected result list event start time to be defined, was 'nil'")
-	}
-	if resultList.Event.StartTime.Time.Format("15:04:05-07:00") != "10:00:00+01:00" {
-		t.Errorf("Expected result list event start time to be '10:00:00+01:00', found %s", resultList.Event.StartTime.Time.Format("15:04:05-07:00"))
-	}
-	if resultList.Event.StartTime.Time.Format(time.RFC3339) != "2011-07-30T10:00:00+01:00" {
-		t.Errorf("Expected result list event start time to be '2011-07-30T10:00:00+01:00', found %s", resultList.Event.StartTime.Time.Format(time.RFC3339))
-	}
-}
-func TestMarshalV3ResultList(t *testing.T) {
-	file := readFile("../../test/v3-examples/ResultList3.xml")
-	resultList := UnmarshalIofV3ResultList(string(file))
-	_, err := MarshallIofXml(resultList)
-
+	list, err := DecodeAs[iof_v3.ResultList](data)
 	if err != nil {
-		t.Fatalf("Could not marshal result list: %s", err)
+		t.Fatalf("DecodeAs: %v", err)
 	}
-}
-func TestMarshalV3CourseData(t *testing.T) {
-	file := readFile("../../test/v3-examples/CourseData_Individual_Step2.xml")
-	courseData := UnmarshalIofV3CourseData(string(file))
-	_, err := MarshallIofXml(courseData)
 
-	if err != nil {
-		t.Fatalf("Could not marshal course data list: %s", err)
+	if got, want := list.Event.Name, "Example event"; got != want {
+		t.Errorf("Event.Name = %q, want %q", got, want)
+	}
+	if got, want := list.Event.StartTime.Date, "2011-07-30"; got != want {
+		t.Errorf("Event.StartTime.Date = %q, want %q", got, want)
+	}
+	if list.Event.StartTime.Time == nil {
+		t.Fatal("Event.StartTime.Time is nil")
+	}
+	if got, want := list.Event.StartTime.Time.Format(time.RFC3339), "2011-07-30T10:00:00+01:00"; got != want {
+		t.Errorf("Event.StartTime.Time = %q, want %q", got, want)
 	}
 }
 
-func TestMarshalV3CourseDataToJson(t *testing.T) {
-	file := readFile("../../test/v3-examples/StartList1.xml")
-	courseData := UnmarshalIofV3StartList(string(file))
-	_, err := MarshallToIofUnofficialJson(courseData)
+func TestDecodeReturnsCorrectType(t *testing.T) {
+	data := readFile(t, filepath.Join(examplesDir, "ResultList3.xml"))
 
+	got, err := Decode(data)
 	if err != nil {
-		t.Fatalf("Could not marshal course data list: %s", err)
+		t.Fatal(err)
+	}
+	if _, ok := got.(*iof_v3.ResultList); !ok {
+		t.Fatalf("Decode returned %T, want *iof_v3.ResultList", got)
 	}
 }
 
-func readFile(fileName string) []byte {
-	file, err := os.Open(fileName)
+func TestDecodeReaderEquivalentToDecode(t *testing.T) {
+	data := readFile(t, filepath.Join(examplesDir, "StartList1.xml"))
 
+	a, err := Decode(data)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	defer file.Close()
-
-	// read our opened xmlFile as a byte array.
-	byteValue, err := io.ReadAll(file)
+	b, err := DecodeReader(bytes.NewReader(data))
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
+	}
+	if _, ok := a.(*iof_v3.StartList); !ok {
+		t.Fatalf("Decode returned %T", a)
+	}
+	if _, ok := b.(*iof_v3.StartList); !ok {
+		t.Fatalf("DecodeReader returned %T", b)
+	}
+}
+
+func TestDecodeStripsUTF8BOM(t *testing.T) {
+	raw := readFile(t, filepath.Join(examplesDir, "ResultList3.xml"))
+	withBOM := append([]byte{0xEF, 0xBB, 0xBF}, raw...)
+
+	if _, err := Decode(withBOM); err != nil {
+		t.Fatalf("Decode with BOM: %v", err)
+	}
+}
+
+func TestDecodeUnknownRootElement(t *testing.T) {
+	_, err := Decode([]byte(`<?xml version="1.0"?><NotAnIofDocument/>`))
+	if err == nil {
+		t.Fatal("expected error for unknown root element")
+	}
+	if !strings.Contains(err.Error(), "unknown IOF v3 root element") {
+		t.Errorf("error = %v, want unknown root element error", err)
+	}
+}
+
+func TestDecodeEmptyInput(t *testing.T) {
+	if _, err := Decode(nil); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+	if _, err := Decode([]byte{}); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+	if _, err := Decode([]byte("\xEF\xBB\xBF")); err == nil {
+		t.Fatal("expected error for BOM-only input")
+	}
+}
+
+func TestDecodeAsWrongType(t *testing.T) {
+	data := readFile(t, filepath.Join(examplesDir, "ResultList3.xml"))
+	_, err := DecodeAs[iof_v3.StartList](data)
+	if err == nil {
+		t.Fatal("expected error when decoding ResultList as StartList")
+	}
+}
+
+func TestEncodeXMLRoundTrip(t *testing.T) {
+	data := readFile(t, filepath.Join(examplesDir, "ResultList3.xml"))
+
+	list, err := DecodeAs[iof_v3.ResultList](data)
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	return byteValue
+	out, err := EncodeXML(list)
+	if err != nil {
+		t.Fatalf("EncodeXML: %v", err)
+	}
+	if !bytes.HasPrefix(out, []byte(`<?xml`)) {
+		t.Errorf("EncodeXML output missing XML declaration: %q", out[:min(80, len(out))])
+	}
+
+	roundTripped, err := DecodeAs[iof_v3.ResultList](out)
+	if err != nil {
+		t.Fatalf("re-decode of encoded XML: %v", err)
+	}
+	if roundTripped.Event.Name != list.Event.Name {
+		t.Errorf("Event.Name lost in round-trip: got %q, want %q", roundTripped.Event.Name, list.Event.Name)
+	}
+}
+
+func TestEncodeXMLCourseData(t *testing.T) {
+	data := readFile(t, filepath.Join(examplesDir, "CourseData_Individual_Step2.xml"))
+
+	cd, err := DecodeAs[iof_v3.CourseData](data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := EncodeXML(cd); err != nil {
+		t.Fatalf("EncodeXML: %v", err)
+	}
+}
+
+func TestEncodeJSON(t *testing.T) {
+	data := readFile(t, filepath.Join(examplesDir, "StartList1.xml"))
+
+	sl, err := DecodeAs[iof_v3.StartList](data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := EncodeJSON(sl)
+	if err != nil {
+		t.Fatalf("EncodeJSON: %v", err)
+	}
+	if !bytes.HasPrefix(bytes.TrimSpace(out), []byte("{")) {
+		t.Errorf("EncodeJSON did not produce a JSON object")
+	}
+}
+
+func readFile(t *testing.T, name string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return b
 }


### PR DESCRIPTION
## Summary

Replaces the old `pkg/marshallers` API with a small, idiomatic surface area. Library code no longer logs to stdout or swallows errors.

New API:

| Function | Purpose |
| --- | --- |
| `Decode([]byte) (any, error)` | Dispatch by root element |
| `DecodeReader(io.Reader) (any, error)` | Same, from an `io.Reader` |
| `DecodeAs[T Document]([]byte) (*T, error)` | Typed, generic helper |
| `EncodeXML(any) ([]byte, error)` | XML with declaration + indentation |
| `EncodeJSON(any) ([]byte, error)` | Indented JSON (mirrors XML shape) |

## Bug fixes

- BOM trimming no longer panics on inputs shorter than the BOM
- The v3 decoder is configured with `golang.org/x/net/html/charset` so documents declaring non-UTF-8 encodings decode correctly (this was missing for v3 in the old code)
- `DecodeAs` validates the root element name against `T`
- All functions return errors instead of printing them

## Tests

- Subtests per example file
- New cases: BOM, unknown root, empty input, type mismatch, round-trip
- All examples still parse, all assertions still hold

## Breaking changes

The entire public API of `pkg/marshallers` is replaced.

Removed:
- `MarshallIofXml`
- `MarshallToIofUnofficialJson`
- `GenericUnmarshalV3Xml`
- `UnmarshalIofV3CompetitorList` … `UnmarshalIofV3ControlCardList`

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `staticcheck ./...` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)