### PR TITLE
feat(iof_v3): add typed enum constants for XSD enumerations

### DIFF
--- a/pkg/iof_v3/enums.go
+++ b/pkg/iof_v3/enums.go
@@ -1,0 +1,90 @@
+package iof_v3
+
+// Constants for the enumerated typed-string fields defined in the IOF v3
+// XSD. Use these instead of string literals so the compiler catches typos
+// and renames; refactoring tooling will follow them across the codebase.
+//
+// The values mirror the XSD's <xsd:enumeration> entries exactly. See the
+// "Related" links in doc.go for the canonical schema.
+
+// EventForm values (Event/Form).
+const (
+	EventFormIndividual EventForm = "Individual"
+	EventFormTeam       EventForm = "Team"
+	EventFormRelay      EventForm = "Relay"
+)
+
+// EventStatus values (Event/Status).
+const (
+	EventStatusPlanned     EventStatus = "Planned"
+	EventStatusApplied     EventStatus = "Applied"
+	EventStatusProposed    EventStatus = "Proposed"
+	EventStatusSanctioned  EventStatus = "Sanctioned"
+	EventStatusCanceled    EventStatus = "Canceled"
+	EventStatusRescheduled EventStatus = "Rescheduled"
+)
+
+// EventClassification values (Event/Classification).
+const (
+	EventClassificationInternational EventClassification = "International"
+	EventClassificationNational      EventClassification = "National"
+	EventClassificationRegional      EventClassification = "Regional"
+	EventClassificationLocal         EventClassification = "Local"
+	EventClassificationClub          EventClassification = "Club"
+)
+
+// RaceDiscipline values (Race/Discipline).
+const (
+	RaceDisciplineSprint    RaceDiscipline = "Sprint"
+	RaceDisciplineMiddle    RaceDiscipline = "Middle"
+	RaceDisciplineLong      RaceDiscipline = "Long"
+	RaceDisciplineUltralong RaceDiscipline = "Ultralong"
+	RaceDisciplineOther     RaceDiscipline = "Other"
+)
+
+// EventClassStatus values (Class/Status).
+const (
+	EventClassStatusNormal           EventClassStatus = "Normal"
+	EventClassStatusDivided          EventClassStatus = "Divided"
+	EventClassStatusJoined           EventClassStatus = "Joined"
+	EventClassStatusInvalidated      EventClassStatus = "Invalidated"
+	EventClassStatusInvalidatedNoFee EventClassStatus = "InvalidatedNoFee"
+)
+
+// RaceClassStatus values (RaceClass/Status).
+const (
+	RaceClassStatusStartTimesNotAllocated RaceClassStatus = "StartTimesNotAllocated"
+	RaceClassStatusStartTimesAllocated    RaceClassStatus = "StartTimesAllocated"
+	RaceClassStatusNotUsed                RaceClassStatus = "NotUsed"
+	RaceClassStatusCompleted              RaceClassStatus = "Completed"
+	RaceClassStatusInvalidated            RaceClassStatus = "Invalidated"
+	RaceClassStatusInvalidatedNoFee       RaceClassStatus = "InvalidatedNoFee"
+)
+
+// ResultStatus values (PersonRaceResult/Status, TeamMemberRaceResult/Status).
+const (
+	ResultStatusOK                 ResultStatus = "OK"
+	ResultStatusFinished           ResultStatus = "Finished"
+	ResultStatusMissingPunch       ResultStatus = "MissingPunch"
+	ResultStatusDisqualified       ResultStatus = "Disqualified"
+	ResultStatusDidNotFinish       ResultStatus = "DidNotFinish"
+	ResultStatusActive             ResultStatus = "Active"
+	ResultStatusInactive           ResultStatus = "Inactive"
+	ResultStatusOverTime           ResultStatus = "OverTime"
+	ResultStatusSportingWithdrawal ResultStatus = "SportingWithdrawal"
+	ResultStatusNotCompeting       ResultStatus = "NotCompeting"
+	ResultStatusMoved              ResultStatus = "Moved"
+	ResultStatusMovedUp            ResultStatus = "MovedUp"
+	ResultStatusDidNotStart        ResultStatus = "DidNotStart"
+	ResultStatusDidNotEnter        ResultStatus = "DidNotEnter"
+	ResultStatusCancelled          ResultStatus = "Cancelled"
+)
+
+// ControlType values (Control/type attribute).
+const (
+	ControlTypeControl          ControlType = "Control"
+	ControlTypeStart            ControlType = "Start"
+	ControlTypeFinish           ControlType = "Finish"
+	ControlTypeCrossingPoint    ControlType = "CrossingPoint"
+	ControlTypeEndOfMarkedRoute ControlType = "EndOfMarkedRoute"
+)

--- a/pkg/iof_v3/enums_test.go
+++ b/pkg/iof_v3/enums_test.go
@@ -1,0 +1,37 @@
+package iof_v3_test
+
+import (
+	"bytes"
+	"encoding/xml"
+	"testing"
+
+	"github.com/mikaello/go-iof-xml/pkg/iof_v3"
+)
+
+// TestEnumConstantsAreXMLValid verifies the enum constants round-trip
+// through encoding/xml so they are usable as drop-in replacements for the
+// underlying string literals.
+func TestEnumConstantsAreXMLValid(t *testing.T) {
+	type result struct {
+		XMLName xml.Name            `xml:"PersonRaceResult"`
+		Status  iof_v3.ResultStatus `xml:"Status"`
+	}
+
+	want := iof_v3.ResultStatusMissingPunch
+
+	encoded, err := xml.Marshal(result{Status: want})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(encoded, []byte("<Status>MissingPunch</Status>")) {
+		t.Errorf("marshalled XML = %q, want it to contain <Status>MissingPunch</Status>", encoded)
+	}
+
+	var got result
+	if err := xml.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Status != want {
+		t.Errorf("Status = %q, want %q", got.Status, want)
+	}
+}


### PR DESCRIPTION
## Summary

The IOF v3 XSD defines eight named `simpleType` enumerations:

- `EventForm`, `EventStatus`, `EventClassification`, `RaceDiscipline`
- `EventClassStatus`, `RaceClassStatus`
- `ResultStatus`, `ControlType`

The previous generated code declared these as Go typed strings (`type ResultStatus string`) without exporting their permitted values, forcing callers to write magic strings like `\"OK\"` or `\"DidNotFinish\"`. Java/JAXB and C#/xsd.exe both emit constants for these — it's the standard expectation for XSD-derived bindings.

## What's in scope

- New `pkg/iof_v3/enums.go` exporting ~50 typed constants (e.g. `iof_v3.ResultStatusMissingPunch`).
- Values mirror the XSD `<xsd:enumeration>` entries verbatim.
- A small round-trip test confirming one constant serialises/deserialises through `encoding/xml` correctly.

## What's deliberately not here

I considered and rejected:
- Lookup/filter helpers (\"find person by ID\")  → belongs in user code
- Builders / constructors for document types → premature; users build whatever they need
- Time conversion (`float64` seconds ↔ `time.Duration`) → trivial one-liner, not worth abstracting
- Constants for *inline* (anonymous) attribute enums like `ResultList/status` (\"Complete\"/\"Delta\"/\"Snapshot\") → the field is plain `string` rather than a named type, so there's no natural place for them

These constants are the only utility surface I think pure XSD bindings should grow.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet`, `gofmt`, `staticcheck` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)