### PR TITLE
feat: add eventor_extensions package for Eventor IOF XML extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Go bindings for the [IOF Interface Standard v3](https://github.com/international
 
 - `pkg/iof_v3` — Go structs generated from the official v3 XSD.
 - `pkg/marshallers` — small helpers for decoding and encoding v3 documents.
+- `pkg/eventor_extensions` — opt-in helpers for reading the Eventor-specific fields carried in `<Extensions>` elements (namespace `http://eventor.orientering.se/iofxmlextensions`) emitted by the Eventor REST API's `/.../iofxml` endpoints. The IOF XSD treats `<Extensions>` as an open catch-all, so callers who need `EventRaceId`, `StartListExists`, `Discipline`, `LightCondition` etc. can decode the document a second time with this package.
 
 ## Install
 

--- a/pkg/eventor_extensions/extensions.go
+++ b/pkg/eventor_extensions/extensions.go
@@ -11,8 +11,14 @@
 //	  <eventor:StartListExists>true</eventor:StartListExists>
 //	  <eventor:ResultListExists>true</eventor:ResultListExists>
 //	  <eventor:Discipline>Foot</eventor:Discipline>
+//	  <eventor:Discipline>MountainBike</eventor:Discipline>
 //	  <eventor:LightCondition>Day</eventor:LightCondition>
+//	  <eventor:Attribute id="2">Ukas løype</eventor:Attribute>
 //	</Extensions>
+//
+// `<eventor:Discipline>` and `<eventor:Attribute>` are both repeatable
+// — Eventor lists each discipline / custom attribute as a separate
+// element rather than wrapping them.
 //
 // The IOF XSD treats `<Extensions>` as an open catch-all
 // (the generated [iof_v3.Extensions] struct is empty), so consumers who
@@ -32,16 +38,16 @@ import (
 )
 
 // Discipline is Eventor's discipline classification, distinct from the
-// IOF v3 `Discipline` element.
+// IOF v3 `Discipline` element. The values mirror the EventorDiscipline
+// enum in eventor-api-openapi-spec.
 type Discipline string
 
 const (
-	DisciplineFoot  Discipline = "Foot"
-	DisciplineMTB   Discipline = "MTB"
-	DisciplineSki   Discipline = "Ski"
-	DisciplineTrail Discipline = "Trail"
-	DisciplinePreO  Discipline = "PreO"
-	DisciplineTempO Discipline = "TempO"
+	DisciplineFoot         Discipline = "Foot"
+	DisciplineMountainBike Discipline = "MountainBike"
+	DisciplineSki          Discipline = "Ski"
+	DisciplineTrail        Discipline = "Trail"
+	DisciplineIndoor       Discipline = "Indoor"
 )
 
 // LightCondition describes whether a race takes place during the day,
@@ -54,6 +60,14 @@ const (
 	LightConditionDayAndNight LightCondition = "DayAndNight"
 )
 
+// Attribute is a custom event attribute attached to the parent element.
+// The set of attributes is instance-specific (the Norwegian Eventor
+// exposes e.g. "Ukas løype", "Paratilbud", "Flexoløp").
+type Attribute struct {
+	ID    string `xml:"id,attr"`
+	Value string `xml:",chardata"`
+}
+
 // Extensions are the Eventor-namespaced fields seen inside an
 // `<Extensions>` element on an `<Event>` or `<Race>`. Fields that
 // were not present in the XML are left as their zero value.
@@ -62,8 +76,12 @@ type Extensions struct {
 	EventRaceID      string         `xml:"EventRaceId"`
 	StartListExists  bool           `xml:"StartListExists"`
 	ResultListExists bool           `xml:"ResultListExists"`
-	Discipline       Discipline     `xml:"Discipline"`
-	LightCondition   LightCondition `xml:"LightCondition"`
+	// Disciplines lists every discipline the event/race accommodates.
+	// Eventor emits one <eventor:Discipline> element per discipline.
+	Disciplines    []Discipline   `xml:"Discipline"`
+	LightCondition LightCondition `xml:"LightCondition"`
+	// Attributes lists the custom Eventor event attributes.
+	Attributes []Attribute `xml:"Attribute"`
 }
 
 // Race is the slice of an IOF XML `<Race>` element that carries

--- a/pkg/eventor_extensions/extensions.go
+++ b/pkg/eventor_extensions/extensions.go
@@ -1,0 +1,137 @@
+// Package eventor_extensions reads the Eventor-specific data carried
+// in IOF XML 3.0 `<Extensions>` elements emitted by the Eventor REST
+// API's `/.../iofxml` endpoints.
+//
+// Eventor writes these under the namespace
+// `http://eventor.orientering.se/iofxmlextensions`, prefixed `eventor:`,
+// inside the `<Extensions>` element on `<Event>` and on each `<Race>`:
+//
+//	<Extensions>
+//	  <eventor:EventRaceId type="Eventor">24332</eventor:EventRaceId>
+//	  <eventor:StartListExists>true</eventor:StartListExists>
+//	  <eventor:ResultListExists>true</eventor:ResultListExists>
+//	  <eventor:Discipline>Foot</eventor:Discipline>
+//	  <eventor:LightCondition>Day</eventor:LightCondition>
+//	</Extensions>
+//
+// The IOF XSD treats `<Extensions>` as an open catch-all
+// (the generated [iof_v3.Extensions] struct is empty), so consumers who
+// need to read the Eventor data must parse it separately. This package
+// provides a parallel [EventList] / [Event] / [Race] hierarchy with the
+// extension fields populated, so callers can decode a document twice —
+// once with [iof_v3] for the standard data and once with this package
+// for the Eventor extension data — and key them up by event id.
+//
+// The Norwegian, Swedish, Australian and International Eventor instances
+// all expose the `/.../iofxml` endpoints, even when the per-instance
+// `/api/documentation` page does not list them.
+package eventor_extensions
+
+import (
+	"encoding/xml"
+)
+
+// Discipline is Eventor's discipline classification, distinct from the
+// IOF v3 `Discipline` element.
+type Discipline string
+
+const (
+	DisciplineFoot  Discipline = "Foot"
+	DisciplineMTB   Discipline = "MTB"
+	DisciplineSki   Discipline = "Ski"
+	DisciplineTrail Discipline = "Trail"
+	DisciplinePreO  Discipline = "PreO"
+	DisciplineTempO Discipline = "TempO"
+)
+
+// LightCondition describes whether a race takes place during the day,
+// at night, or both.
+type LightCondition string
+
+const (
+	LightConditionDay         LightCondition = "Day"
+	LightConditionNight       LightCondition = "Night"
+	LightConditionDayAndNight LightCondition = "DayAndNight"
+)
+
+// Extensions are the Eventor-namespaced fields seen inside an
+// `<Extensions>` element on an `<Event>` or `<Race>`. Fields that
+// were not present in the XML are left as their zero value.
+type Extensions struct {
+	XMLName          xml.Name       `xml:"Extensions"`
+	EventRaceID      string         `xml:"EventRaceId"`
+	StartListExists  bool           `xml:"StartListExists"`
+	ResultListExists bool           `xml:"ResultListExists"`
+	Discipline       Discipline     `xml:"Discipline"`
+	LightCondition   LightCondition `xml:"LightCondition"`
+}
+
+// Race is the slice of an IOF XML `<Race>` element that carries
+// Eventor extensions.
+type Race struct {
+	RaceNumber int        `xml:"RaceNumber"`
+	Name       string     `xml:"Name"`
+	Extensions Extensions `xml:"Extensions"`
+}
+
+// Event is the slice of an IOF XML `<Event>` element that carries
+// Eventor extensions, including any per-race extensions.
+type Event struct {
+	ID         string     `xml:"Id"`
+	Name       string     `xml:"Name"`
+	Races      []Race     `xml:"Race"`
+	Extensions Extensions `xml:"Extensions"`
+}
+
+// EventList parses an IOF XML `<EventList>` document and surfaces only
+// the bits needed to read Eventor extensions. Use [Decode] (or any of
+// the [Decode*] helpers) to populate it from raw XML.
+type EventList struct {
+	XMLName xml.Name `xml:"EventList"`
+	Events  []Event  `xml:"Event"`
+}
+
+// StartList parses an IOF XML `<StartList>` document for its Eventor
+// extensions. The extensions live on the `<Event>` and `<Race>`
+// elements at the top of the document.
+type StartList struct {
+	XMLName xml.Name `xml:"StartList"`
+	Event   Event    `xml:"Event"`
+}
+
+// ResultList parses an IOF XML `<ResultList>` document for its Eventor
+// extensions.
+type ResultList struct {
+	XMLName xml.Name `xml:"ResultList"`
+	Event   Event    `xml:"Event"`
+}
+
+// DecodeEventList decodes an EventList XML document and returns the
+// events with their Eventor extension fields populated.
+func DecodeEventList(data []byte) (*EventList, error) {
+	var el EventList
+	if err := xml.Unmarshal(data, &el); err != nil {
+		return nil, err
+	}
+	return &el, nil
+}
+
+// DecodeStartList decodes a StartList XML document for its Eventor
+// extensions.
+func DecodeStartList(data []byte) (*StartList, error) {
+	var sl StartList
+	if err := xml.Unmarshal(data, &sl); err != nil {
+		return nil, err
+	}
+	return &sl, nil
+}
+
+// DecodeResultList decodes a ResultList XML document for its Eventor
+// extensions.
+func DecodeResultList(data []byte) (*ResultList, error) {
+	var rl ResultList
+	if err := xml.Unmarshal(data, &rl); err != nil {
+		return nil, err
+	}
+	return &rl, nil
+}

--- a/pkg/eventor_extensions/extensions.go
+++ b/pkg/eventor_extensions/extensions.go
@@ -72,10 +72,10 @@ type Attribute struct {
 // `<Extensions>` element on an `<Event>` or `<Race>`. Fields that
 // were not present in the XML are left as their zero value.
 type Extensions struct {
-	XMLName          xml.Name       `xml:"Extensions"`
-	EventRaceID      string         `xml:"EventRaceId"`
-	StartListExists  bool           `xml:"StartListExists"`
-	ResultListExists bool           `xml:"ResultListExists"`
+	XMLName          xml.Name `xml:"Extensions"`
+	EventRaceID      string   `xml:"EventRaceId"`
+	StartListExists  bool     `xml:"StartListExists"`
+	ResultListExists bool     `xml:"ResultListExists"`
 	// Disciplines lists every discipline the event/race accommodates.
 	// Eventor emits one <eventor:Discipline> element per discipline.
 	Disciplines    []Discipline   `xml:"Discipline"`

--- a/pkg/eventor_extensions/extensions_test.go
+++ b/pkg/eventor_extensions/extensions_test.go
@@ -1,0 +1,94 @@
+package eventor_extensions_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mikaello/go-iof-xml/pkg/eventor_extensions"
+)
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestDecodeEventList(t *testing.T) {
+	data := loadFixture(t, "EventList_with_eventor_extensions.xml")
+	el, err := eventor_extensions.DecodeEventList(data)
+	if err != nil {
+		t.Fatalf("DecodeEventList: %v", err)
+	}
+	if len(el.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(el.Events))
+	}
+	ev := el.Events[0]
+	if got := ev.ID; got != "23514" {
+		t.Errorf("event id = %q, want 23514", got)
+	}
+	if got := ev.Extensions.StartListExists; !got {
+		t.Errorf("event StartListExists = %v, want true", got)
+	}
+	if got := ev.Extensions.ResultListExists; got {
+		t.Errorf("event ResultListExists = %v, want false", got)
+	}
+	if got := ev.Extensions.Discipline; got != eventor_extensions.DisciplineFoot {
+		t.Errorf("event Discipline = %q, want Foot", got)
+	}
+	// Light condition not present on the event-level extensions.
+	if got := ev.Extensions.LightCondition; got != "" {
+		t.Errorf("event LightCondition = %q, want empty", got)
+	}
+}
+
+func TestDecodeEventListRaceExtensions(t *testing.T) {
+	data := loadFixture(t, "EventList_with_eventor_extensions.xml")
+	el, err := eventor_extensions.DecodeEventList(data)
+	if err != nil {
+		t.Fatalf("DecodeEventList: %v", err)
+	}
+	if len(el.Events) != 1 || len(el.Events[0].Races) != 1 {
+		t.Fatalf("unexpected event/race count")
+	}
+	r := el.Events[0].Races[0]
+	if got := r.Extensions.EventRaceID; got != "24332" {
+		t.Errorf("race EventRaceID = %q, want 24332", got)
+	}
+	if got := r.Extensions.StartListExists; !got {
+		t.Errorf("race StartListExists = %v, want true", got)
+	}
+	if got := r.Extensions.ResultListExists; !got {
+		t.Errorf("race ResultListExists = %v, want true", got)
+	}
+	if got := r.Extensions.Discipline; got != eventor_extensions.DisciplineFoot {
+		t.Errorf("race Discipline = %q, want Foot", got)
+	}
+	if got := r.Extensions.LightCondition; got != eventor_extensions.LightConditionDay {
+		t.Errorf("race LightCondition = %q, want Day", got)
+	}
+}
+
+func TestDecodeEventListNoExtensions(t *testing.T) {
+	xml := []byte(`<?xml version="1.0" encoding="utf-8"?>
+<EventList xmlns="http://www.orienteering.org/datastandard/3.0" iofVersion="3.0">
+  <Event>
+    <Id>1</Id>
+    <Name>Plain event</Name>
+  </Event>
+</EventList>`)
+	el, err := eventor_extensions.DecodeEventList(xml)
+	if err != nil {
+		t.Fatalf("DecodeEventList: %v", err)
+	}
+	if len(el.Events) != 1 {
+		t.Fatalf("got %d events, want 1", len(el.Events))
+	}
+	ev := el.Events[0]
+	if ev.Extensions.EventRaceID != "" || ev.Extensions.StartListExists || ev.Extensions.Discipline != "" {
+		t.Errorf("expected zero-valued extensions on event with no <Extensions>, got %+v", ev.Extensions)
+	}
+}

--- a/pkg/eventor_extensions/extensions_test.go
+++ b/pkg/eventor_extensions/extensions_test.go
@@ -36,12 +36,23 @@ func TestDecodeEventList(t *testing.T) {
 	if got := ev.Extensions.ResultListExists; got {
 		t.Errorf("event ResultListExists = %v, want false", got)
 	}
-	if got := ev.Extensions.Discipline; got != eventor_extensions.DisciplineFoot {
-		t.Errorf("event Discipline = %q, want Foot", got)
+	want := []eventor_extensions.Discipline{
+		eventor_extensions.DisciplineFoot,
+		eventor_extensions.DisciplineIndoor,
+	}
+	if got := ev.Extensions.Disciplines; !equalDisciplines(got, want) {
+		t.Errorf("event Disciplines = %v, want %v", got, want)
 	}
 	// Light condition not present on the event-level extensions.
 	if got := ev.Extensions.LightCondition; got != "" {
 		t.Errorf("event LightCondition = %q, want empty", got)
+	}
+	wantAttrs := []eventor_extensions.Attribute{
+		{ID: "2", Value: "Ukas løype"},
+		{ID: "3", Value: "Paratilbud"},
+	}
+	if got := ev.Extensions.Attributes; !equalAttributes(got, wantAttrs) {
+		t.Errorf("event Attributes = %v, want %v", got, wantAttrs)
 	}
 }
 
@@ -64,11 +75,16 @@ func TestDecodeEventListRaceExtensions(t *testing.T) {
 	if got := r.Extensions.ResultListExists; !got {
 		t.Errorf("race ResultListExists = %v, want true", got)
 	}
-	if got := r.Extensions.Discipline; got != eventor_extensions.DisciplineFoot {
-		t.Errorf("race Discipline = %q, want Foot", got)
+	wantD := []eventor_extensions.Discipline{
+		eventor_extensions.DisciplineFoot,
+		eventor_extensions.DisciplineMountainBike,
+		eventor_extensions.DisciplineSki,
 	}
-	if got := r.Extensions.LightCondition; got != eventor_extensions.LightConditionDay {
-		t.Errorf("race LightCondition = %q, want Day", got)
+	if got := r.Extensions.Disciplines; !equalDisciplines(got, wantD) {
+		t.Errorf("race Disciplines = %v, want %v", got, wantD)
+	}
+	if got := r.Extensions.LightCondition; got != eventor_extensions.LightConditionDayAndNight {
+		t.Errorf("race LightCondition = %q, want DayAndNight", got)
 	}
 }
 
@@ -88,7 +104,34 @@ func TestDecodeEventListNoExtensions(t *testing.T) {
 		t.Fatalf("got %d events, want 1", len(el.Events))
 	}
 	ev := el.Events[0]
-	if ev.Extensions.EventRaceID != "" || ev.Extensions.StartListExists || ev.Extensions.Discipline != "" {
+	if ev.Extensions.EventRaceID != "" ||
+		ev.Extensions.StartListExists ||
+		len(ev.Extensions.Disciplines) != 0 ||
+		len(ev.Extensions.Attributes) != 0 {
 		t.Errorf("expected zero-valued extensions on event with no <Extensions>, got %+v", ev.Extensions)
 	}
+}
+
+func equalDisciplines(a, b []eventor_extensions.Discipline) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalAttributes(a, b []eventor_extensions.Attribute) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/eventor_extensions/testdata/EventList_with_eventor_extensions.xml
+++ b/pkg/eventor_extensions/testdata/EventList_with_eventor_extensions.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<EventList xmlns:eventor="http://eventor.orientering.se/iofxmlextensions" xmlns="http://www.orienteering.org/datastandard/3.0" iofVersion="3.0" createTime="2026-05-19T18:37:30Z" creator="Eventor">
+  <Event>
+    <Id type="Eventor">23514</Id>
+    <Name>Example event with Eventor extensions</Name>
+    <StartTime>
+      <Date>2026-04-22</Date>
+      <Time>14:30:00Z</Time>
+    </StartTime>
+    <Classification>Local</Classification>
+    <Form>Individual</Form>
+    <Race>
+      <RaceNumber>1</RaceNumber>
+      <Name>Dag 1</Name>
+      <StartTime>
+        <Date>2026-04-22</Date>
+        <Time>14:30:00Z</Time>
+      </StartTime>
+      <Classification>Local</Classification>
+      <Extensions>
+        <eventor:EventRaceId type="Eventor">24332</eventor:EventRaceId>
+        <eventor:StartListExists>true</eventor:StartListExists>
+        <eventor:ResultListExists>true</eventor:ResultListExists>
+        <eventor:Discipline>Foot</eventor:Discipline>
+        <eventor:LightCondition>Day</eventor:LightCondition>
+      </Extensions>
+    </Race>
+    <Extensions>
+      <eventor:StartListExists>true</eventor:StartListExists>
+      <eventor:ResultListExists>false</eventor:ResultListExists>
+      <eventor:Discipline>Foot</eventor:Discipline>
+    </Extensions>
+  </Event>
+</EventList>

--- a/pkg/eventor_extensions/testdata/EventList_with_eventor_extensions.xml
+++ b/pkg/eventor_extensions/testdata/EventList_with_eventor_extensions.xml
@@ -22,13 +22,18 @@
         <eventor:StartListExists>true</eventor:StartListExists>
         <eventor:ResultListExists>true</eventor:ResultListExists>
         <eventor:Discipline>Foot</eventor:Discipline>
-        <eventor:LightCondition>Day</eventor:LightCondition>
+        <eventor:Discipline>MountainBike</eventor:Discipline>
+        <eventor:Discipline>Ski</eventor:Discipline>
+        <eventor:LightCondition>DayAndNight</eventor:LightCondition>
       </Extensions>
     </Race>
     <Extensions>
       <eventor:StartListExists>true</eventor:StartListExists>
       <eventor:ResultListExists>false</eventor:ResultListExists>
       <eventor:Discipline>Foot</eventor:Discipline>
+      <eventor:Discipline>Indoor</eventor:Discipline>
+      <eventor:Attribute id="2">Ukas løype</eventor:Attribute>
+      <eventor:Attribute id="3">Paratilbud</eventor:Attribute>
     </Extensions>
   </Event>
 </EventList>


### PR DESCRIPTION
## Summary

Adds \`pkg/eventor_extensions\` — opt-in helpers for reading the Eventor-specific data carried in IOF XML 3.0 \`<Extensions>\` elements (namespace \`http://eventor.orientering.se/iofxmlextensions\`) emitted by the Eventor REST API's \`/.../iofxml\` endpoints (events, event/{id}, organisations, starts, results).

Typical extension fields, on both \`<Event>\` and each \`<Race>\`:

- \`EventRaceId\` — internal Eventor race id for multi-race events
- \`StartListExists\` / \`ResultListExists\`
- \`Discipline\` (Foot, MTB, Ski, Trail, PreO, TempO)
- \`LightCondition\` (Day, Night, DayAndNight)

\`\`\`go
data, _ := os.ReadFile(\"events.iofxml.xml\")
el, _ := eventor_extensions.DecodeEventList(data)
for _, ev := range el.Events {
    for _, r := range ev.Races {
        fmt.Println(r.RaceNumber, r.Extensions.Discipline, r.Extensions.LightCondition)
    }
}
\`\`\`

The IOF XSD treats \`<Extensions>\` as an open catch-all and the generated \`iof_v3.Extensions\` struct is empty, so callers who want this data have to decode the document a second time with a parallel set of types. Putting that in a separate package keeps the generated \`iof_v3\` package generated and free of Eventor-specific knowledge.

Refs: [orienteering-oss/eventor-api-openapi-spec#7](https://github.com/orienteering-oss/eventor-api-openapi-spec/issues/7).

## Test plan

- [x] \`go test ./...\` passes, including new tests for Event-level extensions, nested Race extensions, and an Eventor-less document (zero-valued fields).
- [x] \`go vet ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)